### PR TITLE
handle instances with no IP

### DIFF
--- a/lib/asg-detailer/detailer.rb
+++ b/lib/asg-detailer/detailer.rb
@@ -72,7 +72,7 @@ module AsgDetailer
 
         resp[:reservations].each do |r|
           r[:instances].each do |i|
-            ip = i[:private_ip_address]
+            ip = i[:private_ip_address].empty? ? 'IP is N/A' : i[:private_ip_address]
             health = instance_health[i[:instance_id]] ? instance_health[i[:instance_id]] : "State is N/A (Not in LB)"
             puts "    InstanceID: #{i[:instance_id]} : #{ip} : #{health}"
           end

--- a/spec/asg-detailer/detailer_spec.rb
+++ b/spec/asg-detailer/detailer_spec.rb
@@ -5,7 +5,7 @@ describe AsgDetailer::Detailer do
     @asg_name = 'test-asg'
     @lc_name = 'test-lc'
     @lb_name = 'test-lb'
-    @instance_ids = ['i-00000000000000000', 'i-00000000000000001', 'i-00000000000000002']
+    @instance_ids = ['i-00000000000000000', 'i-00000000000000001', 'i-00000000000000002', 'i-00000000000000003']
     setup_aws_stubs(@asg_name, @lc_name, @lb_name, @instance_ids)
     @det = Detailer.new(@asg_name)
   end
@@ -34,7 +34,8 @@ Load Balancer: #{@lb_name}
   Instances:
     InstanceID: i-00000000000000000 : 10.0.0.1 : InService
     InstanceID: i-00000000000000001 : 10.0.0.99 : State is N/A (Not in LB)
-    InstanceID: i-00000000000000002 : 10.0.0.199 : OutOfService\n"
+    InstanceID: i-00000000000000002 : 10.0.0.199 : OutOfService
+    InstanceID: i-00000000000000003 : IP is N/A : State is N/A (Not in LB)\n"
 
     setup_aws_stubs(@asg_name, @lc_name, @lb_name, @instance_ids)
     expect { @det.run }.to output(asg_output).to_stdout

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,6 +41,14 @@ def setup_aws_stubs(asg_name, lc_name, lb_name, instance_ids)
         health_status: "Healthy",
         launch_configuration_name: lc_name,
         protected_from_scale_in: false
+      },
+      'i-00000000000000003': {
+        instance_id: 'i-00000000000000003',
+        availability_zone: "us-west-2b",
+        lifecycle_state: "InService",
+        health_status: "UnHealthy",
+        launch_configuration_name: lc_name,
+        protected_from_scale_in: false
       }
     },
     instances_detail: {
@@ -55,6 +63,10 @@ def setup_aws_stubs(asg_name, lc_name, lb_name, instance_ids)
       'i-00000000000000002': {
         instance_id: 'i-00000000000000002',
         private_ip_address: '10.0.0.199'
+      },
+      'i-00000000000000003': {
+        instance_id: 'i-00000000000000003',
+        private_ip_address: ''
       }
     }
   }


### PR DESCRIPTION
There is at least a point when an instance has been
terminated, but not removed from the ASG, where there is
an instance, but no IP for the instance.  Handle it a bit
more gracefully in the output.